### PR TITLE
Improve solve_sim implementation

### DIFF
--- a/tests/jax/Jax_Kalman.ipynb
+++ b/tests/jax/Jax_Kalman.ipynb
@@ -193,7 +193,7 @@
     "%timeit -o _ = \\\n",
     "    solve_sim(x0_state, tmin, tmax, n_eval, kinit['wgt_state'], \\\n",
     "              kinit['mu_state'], kinit['var_state'], \\\n",
-    "              W, z_state, theta=theta)"
+    "              W, z_state, theta=theta).block_until_ready()"
    ]
   },
   {
@@ -459,16 +459,8 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": ""
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Overall, the JAX code looks good. I changed the in-place updates and loops to be slightly more idiomatic. I verified the outputs match to a relative tolerance of 1e-7 for the example, though please run this yourself as well as I am not aware of edge cases and such. These changes brought a small improvement of ~7% (2.08 ms to 1.93 ms for the example), and enables backward more differentiation.

Some notes:

- In NumPy, it is very common to allocate a buffer then fill it. This rarely needs to be done in JAX (and I personally consider it an anti-pattern). You'll see in `fun`, I just stack the two scalars instead of populating the preallocated buffer. Similarly, in the `sim` functions, I just concatenate values. The XLA compiler does static memory allocation anyway (which is why all shapes must be static), so there is no need to do that yourself.
    - Of course, there are some cases where this is necessary, such as embedding values into a lower triangular matrix. In these cases, there is syntactic sugar for `index_update` that is identical but easier on the eyes: `x = jax.ops.index_update(x, jax.ops.index[::2, 3:], 6.)` is equivalent to `x = x.at[::2, 3:].set(6.)`
- I personally don't JIT library functions, and instead allow the user to just JIT compile their top level function that calls the library functions. JITing the top level function will JIT all lower function calls, as JAX does not see Python functions: it merely traces operations on arrays, and so it has full visibility into the computation graph. Not JIT compiling library code makes it easier for users to debug.
- I rewrote the `fori_loop` and `while_loop` in terms of `scan`. Generally, `scan` is a more optimized, lower level procedure, and allows for both forward and backward mode differentiation (whereas the other two only support forward mode).  
- You'll notice for `solve_sim`, I replaced the indexing with scanning over arguments. Although this resulted in slightly more code (while the other changes I made all reduced code), it provides more information to JAX, which could potentially enable more optimizations. Specifically, we're telling the compiler we're scanning over a particular dimension, instead of merely indexing in a loop. In principle XLA could choose to lay that array out differently in memory to improve cache friendliness, though perhaps it could be clever enough to recognise the indexing pattern anyway (I'm not sure). This change didn't make a measurable perf improvement, but the optimisations are improving all the time, and expressing computational more idiomatically like this has benefited me in the past.
    - As I mentioned in the meeting, I'm able to pass in a dictionary due to how JAX handles "PyTrees", more info [here](https://jax.readthedocs.io/en/latest/pytrees.html).
- JAX has asynchronous execution (to hide Python overhead when not using JIT), so when timing, you should use `.block_until_ready()` to get accurate timings (I added this to the example). More info [here](https://jax.readthedocs.io/en/latest/async_dispatch.html).

I have not yet looked at the overall design in much detail. I think @mlysy's idea about subclassing makes a lot of sense for different likelihood functions. Alternatively, the user can pass in the likelihood function as a higher order function (or select it via an `Enum`) to reduce code duplication.

Hope this is helpful, please let me know if you have any questions.